### PR TITLE
feature: automatic deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Etapa 1: Construcción con Maven y Java 21
+FROM maven:3.9.6-eclipse-temurin-21 AS build
+
+WORKDIR /app
+
+# Copiar los archivos del proyecto y compilar
+COPY pom.xml .
+COPY src ./src
+RUN mvn clean package -U -DskipTests
+
+# Etapa 2: Imagen más ligera con Java 21 para ejecutar la aplicación
+FROM eclipse-temurin:21-jdk
+
+WORKDIR /app
+
+# Copiar el JAR generado desde la fase de construcción
+COPY --from=build /app/target/*.jar app.jar
+
+# Exponer el puerto de la aplicación
+EXPOSE 8083
+
+# Ejecutar un sleep de 30 segundos y luego iniciar la aplicación
+CMD ["sh", "-c", "sleep 30 && java -jar app.jar"]


### PR DESCRIPTION
This pull request introduces a new multi-stage `Dockerfile` for building and running the application using Java 21 and Maven. The Dockerfile optimizes the image size and startup process by separating the build and runtime environments.

**Dockerfile improvements:**

* Added a multi-stage build: the first stage uses the `maven:3.9.6-eclipse-temurin-21` image to build the project, and the second stage uses the lighter `eclipse-temurin:21-jdk` image to run the application.
* Configured the build process to copy project files, run `mvn clean package` (skipping tests), and copy the resulting JAR to the runtime image.
* Exposed port 8083 and set the container to sleep for 30 seconds before starting the Java application, likely to allow dependent services to start.